### PR TITLE
Remove redirects and nonexistent pages from force graph

### DIFF
--- a/specials/SpecialWatchAnalytics.php
+++ b/specials/SpecialWatchAnalytics.php
@@ -244,6 +244,7 @@ class SpecialWatchAnalytics extends SpecialPage {
 			array(
 				'w' => 'watchlist',
 				'u' => 'user',
+				'p' => 'page',
 			),
 			array(
 				'w.wl_title AS title',
@@ -251,7 +252,7 @@ class SpecialWatchAnalytics extends SpecialPage {
 				'u.user_name as user_name',
 				'u.user_real_name AS real_name',
 			),
-			'wl_namespace = 0',
+			'w.wl_namespace = 0 AND p.page_is_redirect = 0',
 			__METHOD__,
 			array(
 				"LIMIT" => "100000",
@@ -259,6 +260,9 @@ class SpecialWatchAnalytics extends SpecialPage {
 			array(
 				'u' => array(
 					'LEFT JOIN', 'u.user_id = w.wl_user'
+				),
+				'p' => array(
+					'RIGHT JOIN', 'w.wl_title = p.page_title AND w.wl_namespace = p.page_namespace'
 				),
 			)
 		);


### PR DESCRIPTION
Special:WatchAnalytics has a force-graph representation of all the
watches in the main namespace of the wiki. Prior to this commit it
included pages which didn't exist (but were in peoples' watchlist)
and redirect-pages. Neither were appropriate.

In a future release, the option of whether or not redirects should
be shown should be selectable via a form input. While selection is
not possible no-redirects is preferable.